### PR TITLE
Implement save credit card token

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,0 +1,36 @@
+$(function() {
+  Payjp.setPublicKey('pk_test_2f7bcffdaa124c05fc4a6e14');
+  var form = $("charge-form"),
+      number = $('input[name="number"]')[0],
+      security_code = $('input[name="security_code"]')[0],
+      exp_month = $('input[name="exp_month"]')[0],
+      exp_year = $('input[name="exp_year"]')[0];
+
+  $("#charge-form").on('submit', function(e) {
+    e.preventDefault();
+    form.find("input[type=submit]").prop("disabled", true);
+
+    var card = {
+        number: number.value,
+        cvc: security_code.value,
+        exp_month: exp_month.value,
+        exp_year: exp_year.value
+    };
+    Payjp.createToken(card, function(s, response) {
+      if (response.error) {
+        form.find('.payment-errors').text(response.error.message);
+        form.find('button').prop('disabled', false);
+      }
+      else {
+        $(".number").removeAttr("name");
+        $(".security_code").removeAttr("name");
+        $(".exp_month").removeAttr("name");
+        $(".exp_year").removeAttr("name");
+
+        var token = response.id;
+        $("#charge-form").append($('<input type="hidden" name="payjpToken" />').val(token));
+        $("#charge-form")[0].submit();
+      }
+    });
+  });
+});

--- a/app/assets/stylesheets/products/_exhibit.scss
+++ b/app/assets/stylesheets/products/_exhibit.scss
@@ -206,7 +206,7 @@
         position: relative;
         left: 200px;
       }
-    &--comment{
+    &--comment {
       font-size: 12px;
       margin-top: 15px;
     }

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -16,16 +16,21 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def card
-    Payjp.api_key = "sk_test_239caee23576c2acc2d0eec8"
+    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+    @user = User.find(params[:format])
 
   end
 
   def create
+    super
     @user = User.create(user_params)
-    render :card
+    session[:user_id] = @user.id
   end
 
   def done
+    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+    @user = User.find(params[:format])
+    @user.update(credit_card_token: params[:payjpToken])
   end
 
   private
@@ -37,7 +42,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def after_sign_up_path_for(resource)
-    new_user_registration_path
+    sign_up_card_path(resource)
+  end
+
+  def current_user
+    @current_user = User.find_by(id: session[:user_id])
   end
 
 end

--- a/app/views/devise/registrations/card.html.haml
+++ b/app/views/devise/registrations/card.html.haml
@@ -27,26 +27,26 @@
   %main.single-main
     .signup-panel
       %h2.signup-panel__head 支払い方法
-      = form_tag(sign_up_done_path, method: "get", id: "charge-form") do
+      = form_tag(sign_up_done_path(@user), method: "post", id: "charge-form") do
         %script{src: "https://checkout.pay.jp/", "data-key": "pk_test_2f7bcffdaa124c05fc4a6e14"}
         .form-group
           = label_tag :number, "カード番号"
           %span.form-group-require 必須
-          = text_field_tag :number, "", {autofocus: true, placeholder: "半角数字のみ", class: "form__input"}
+          = text_field_tag :number, "", {autofocus: true, placeholder: "半角数字のみ", class: "form__input number"}
           = image_tag "credit_logo.png", class: "credit_logo"
         .form-group
           = label_tag :exp_month, "有効期限"
           %span.form-group-require 必須
           %br
-          = number_field_tag :exp_month, "", {autofocus: true, min: "1", max: "12", class: "form__input-exp"}
+          = number_field_tag :exp_month, "", {autofocus: true, min: "1", max: "12", class: "form__input-exp exp_month"}
           月
           %br
-          = number_field_tag :exp_year, "", {autofocus: true, min: "1990", max: "2020", class: "form__input-exp"}
+          = number_field_tag :exp_year, "", {autofocus: true, min: "1990", max: "2020", class: "form__input-exp exp_year"}
           年
         .form-group
-          = label_tag :cvc, "セキュリティコード"
+          = label_tag :security_code, "セキュリティコード"
           %span.form-group-require 必須
-          = text_field_tag :security_code, "", {autofocus: true, placeholder: "カード背面4桁もしくは3桁の番号", class: "form__input"}
+          = text_field_tag :security_code, "", {autofocus: true, placeholder: "カード背面4桁もしくは3桁の番号", class: "form__input security_code"}
           %p.cvc-notice
             %small ？
             カード裏面の番号とは？

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,7 +7,7 @@
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
-    %script{type: "text/javascript", src: "https://js.pay.jp/"}
-    %script{type: "text/javascript"} Payjp.setPublicKey('pk_test_2f7bcffdaa124c05fc4a6e14');
+    %script{:src => "https://js.pay.jp/", :type => "text/javascript"}
+
   %body
     = yield

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,9 @@ Rails.application.routes.draw do
     get "/sign_up/basic_info" => "users/registrations#basic_info"
     post "/sign_up/sms_confirmation" => "users/registrations#sms_confirmation"
     post "/sign_up/address" => "users/registrations#address"
-    post "/sign_up/card" => "users/registrations#card"
+    get "/sign_up/card" => "users/registrations#card"
     post "/sign_up/completed" => "users/registrations#create"
-    get "sign_up/done" => "users/registrations#done"
+    post "sign_up/done" => "users/registrations#done"
   end
 
   root "tops#index"


### PR DESCRIPTION
## What
Payjp クレジットカードトークンの登録

## 内容
- pay.jpを用いてクレジットカードの情報をトークン化してusersテーブルに登録する機能の実装